### PR TITLE
Fixed listFiles() function

### DIFF
--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -28,9 +28,9 @@ class ICloudStorage {
   /// Lists files from the iCloud container directory, which lives on the device
   ///
   /// Returns a future completing with a list of file names
-  Future<List<String>> listFiles() async {
-    return await (_channel.invokeListMethod<String>(
-        'listFiles', {'eventChannelName': ''}) as FutureOr<List<String>>);
+  Future<List<String>?> listFiles() async {
+    return await _channel.invokeListMethod<String>(
+        'listFiles', {'eventChannelName': ''});
   }
 
   /// Lists files from the iCloud container directory, which lives on the


### PR DESCRIPTION
- Removed the type cast to FutureOr<List<String>> 
- Changed the return type from Future<List<String>> to Future<List<String>?>