### PR TITLE
Performance: Improved IO operations (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pubspec.lock
 .idea/
 
 build/
+example/macos/Flutter/GeneratedPluginRegistrant.swift

--- a/example/lib/download.dart
+++ b/example/lib/download.dart
@@ -15,7 +15,6 @@ class Download extends StatefulWidget {
 class _DownloadState extends State<Download> {
   final _containerIdController = TextEditingController();
   final _filePathController = TextEditingController();
-  final _destPathController = TextEditingController();
   StreamSubscription<double>? _progressListner;
   String? _error;
   String? _progress;
@@ -30,7 +29,6 @@ class _DownloadState extends State<Download> {
       await ICloudStorage.download(
         containerId: _containerIdController.text,
         relativePath: _filePathController.text,
-        destinationFilePath: _destPathController.text,
         onProgress: (stream) {
           _progressListner = stream.listen(
             (progress) => setState(() {
@@ -66,7 +64,6 @@ class _DownloadState extends State<Download> {
     _progressListner?.cancel();
     _containerIdController.dispose();
     _filePathController.dispose();
-    _destPathController.dispose();
     super.dispose();
   }
 
@@ -91,12 +88,6 @@ class _DownloadState extends State<Download> {
                 controller: _filePathController,
                 decoration: const InputDecoration(
                   labelText: 'relativePath',
-                ),
-              ),
-              TextField(
-                controller: _destPathController,
-                decoration: const InputDecoration(
-                  labelText: 'destinationFilePath',
                 ),
               ),
               const SizedBox(height: 16),

--- a/lib/icloud_storage.dart
+++ b/lib/icloud_storage.dart
@@ -27,6 +27,16 @@ class ICloudStorage {
     );
   }
 
+  static Future<String?> getContainerPath({
+    required String containerId,
+  }) async {
+    return await ICloudStoragePlatform.instance.getContainerPath(
+      containerId: containerId,
+    );
+  }
+
+  
+
   /// Initiate to upload a file to iCloud
   ///
   /// [containerId] is the iCloud Container Id.
@@ -83,24 +93,18 @@ class ICloudStorage {
   ///
   /// The returned future completes without waiting for the file to be
   /// downloaded
-  static Future<void> download({
+  static Future<bool> download({
     required String containerId,
     required String relativePath,
-    required String destinationFilePath,
     StreamHandler<double>? onProgress,
   }) async {
     if (!_validateRelativePath(relativePath)) {
       throw InvalidArgumentException('invalid relativePath');
     }
-    if (destinationFilePath.trim().isEmpty ||
-        destinationFilePath[destinationFilePath.length - 1] == '/') {
-      throw InvalidArgumentException('invalid destinationFilePath');
-    }
 
-    await ICloudStoragePlatform.instance.download(
+    return await ICloudStoragePlatform.instance.download(
       containerId: containerId,
       relativePath: relativePath,
-      destinationFilePath: destinationFilePath,
       onProgress: onProgress,
     );
   }

--- a/lib/icloud_storage_method_channel.dart
+++ b/lib/icloud_storage_method_channel.dart
@@ -43,6 +43,15 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
   }
 
   @override
+  Future<String?> getContainerPath({required String containerId}) async {
+    final result = await methodChannel.invokeMethod<String>(
+      'getContainerPath',
+      {'containerId': containerId},
+    );
+    return result;
+  }
+
+  @override
   Future<void> upload({
     required String containerId,
     required String filePath,
@@ -75,10 +84,9 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
   }
 
   @override
-  Future<void> download({
+  Future<bool> download({
     required String containerId,
     required String relativePath,
-    required String destinationFilePath,
     StreamHandler<double>? onProgress,
   }) async {
     var eventChannelName = '';
@@ -98,10 +106,9 @@ class MethodChannelICloudStorage extends ICloudStoragePlatform {
       onProgress(stream);
     }
 
-    await methodChannel.invokeMethod('download', {
+    return await methodChannel.invokeMethod('download', {
       'containerId': containerId,
       'cloudFileName': relativePath,
-      'localFilePath': destinationFilePath,
       'eventChannelName': eventChannelName
     });
   }

--- a/lib/icloud_storage_platform_interface.dart
+++ b/lib/icloud_storage_platform_interface.dart
@@ -42,6 +42,13 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
     throw UnimplementedError('gather() has not been implemented.');
   }
 
+
+  Future<String?> getContainerPath({
+    required String containerId,
+  }) async {
+    throw UnimplementedError('getContainerPath() has not been implemented.');
+  }
+
   /// Upload a local file to iCloud.
   ///
   /// [containerId] is the iCloud Container Id.
@@ -81,10 +88,9 @@ abstract class ICloudStoragePlatform extends PlatformInterface {
   ///
   /// The returned future completes without waiting for the file to be
   /// downloaded.
-  Future<void> download({
+  Future<bool> download({
     required String containerId,
     required String relativePath,
-    required String destinationFilePath,
     StreamHandler<double>? onProgress,
   }) async {
     throw UnimplementedError('download() has not been implemented.');

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -30,6 +30,8 @@ void main() {
               'hasUnresolvedConflicts': false,
             }
           ];
+        case 'download':
+          return true;
         default:
           return null;
       }
@@ -97,18 +99,17 @@ void main() {
 
   group('download tests:', () {
     test('download', () async {
-      await platform.download(
+      final result = await platform.download(
         containerId: containerId,
         relativePath: 'file',
       );
       expect((mockMethodCall.arguments['containerId'] as String), containerId);
-      expect(
-          (mockMethodCall.arguments['localFilePath'] as String), '/dir/dest');
       expect((mockMethodCall.arguments['cloudFileName'] as String), 'file');
       expect((mockMethodCall.arguments['eventChannelName'] as String), '');
+      expect(result, true);
     });
 
-    test('upload with onProgress', () async {
+    test('download with onProgress', () async {
       await platform.download(
         containerId: containerId,
         relativePath: 'file',

--- a/test/icloud_storage_method_channel_test.dart
+++ b/test/icloud_storage_method_channel_test.dart
@@ -100,7 +100,6 @@ void main() {
       await platform.download(
         containerId: containerId,
         relativePath: 'file',
-        destinationFilePath: '/dir/dest',
       );
       expect((mockMethodCall.arguments['containerId'] as String), containerId);
       expect(
@@ -113,7 +112,6 @@ void main() {
       await platform.download(
         containerId: containerId,
         relativePath: 'file',
-        destinationFilePath: '/dir/dest',
         onProgress: (stream) => {},
       );
       expect(

--- a/test/icloud_storage_test.dart
+++ b/test/icloud_storage_test.dart
@@ -17,6 +17,11 @@ class MockIcloudStoragePlatform
   String get uploadDestinationRelativePath => _uploadDestinationRelativePath;
 
   @override
+  Future<String> getContainerPath({required String containerId}) async {
+    return '';
+  }
+
+  @override
   Future<List<ICloudFile>> gather({
     required String containerId,
     StreamHandler<List<ICloudFile>>? onUpdate,
@@ -35,12 +40,12 @@ class MockIcloudStoragePlatform
   }
 
   @override
-  Future<void> download(
+  Future<bool> download(
       {required String containerId,
       required String relativePath,
-      required String destinationFilePath,
       StreamHandler<double>? onProgress}) async {
     _calls.add('download');
+    return true;
   }
 
   @override
@@ -137,7 +142,6 @@ void main() {
         await ICloudStorage.download(
           containerId: containerId,
           relativePath: 'file',
-          destinationFilePath: '/dir/file',
         );
         expect(fakePlatform.calls.last, 'download');
       });
@@ -147,29 +151,6 @@ void main() {
           () async => await ICloudStorage.download(
             containerId: containerId,
             relativePath: 'file/',
-            destinationFilePath: 'dir/file',
-          ),
-          throwsException,
-        );
-      });
-
-      test('download with empty destinationFilePath', () async {
-        expect(
-          () async => await ICloudStorage.download(
-            containerId: containerId,
-            relativePath: 'file',
-            destinationFilePath: '',
-          ),
-          throwsException,
-        );
-      });
-
-      test('download with invalid destinationFilePath', () async {
-        expect(
-          () async => await ICloudStorage.download(
-            containerId: containerId,
-            relativePath: 'file',
-            destinationFilePath: 'dir/file/',
           ),
           throwsException,
         );


### PR DESCRIPTION
## Feature Title
Improve IO performance of icloud operations. **closes #43** 

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Description of the Feature

- Provide root directory URI of local iCloud container, files can be manipulated directly and then synced implicitly by OS.
- Return Boolean based acknowledgment for successful `download` method.

## Implementation Details

- A new method channel named `getContainerDirectory` has been introduced to provide root directory of local iCloud container.
- Existing method channel for `download` has been modified to return acknowledgment along with existing `onProgress` callback. `localFilePath` argument has been removed which was used earlier to download and move files to user provided directory (Redundant step).

## Impact of the Feature

- Removes the need of repeated deletion and creation of new file for **upload** operation (existing `upload` method is inefficient) by providing direct access to directory of iCloud container via new method channel enabling client to directly create or manage files. Changes in root directory of local iCloud container reflects remote iCloud space.
- Makes the existing `upload` method redundant.
- Returns future based Boolean acknowledgement on successful download operation of iCloud files which can be used to chain multiple download operations using async/await.

## Testing Conducted
This PR change has been thoroughly tested and is being used in production as local package dependency.

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented on my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [X] I have tested my features thoroughly in different environments.
- [X] I have added tests that prove my feature works as intended.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have assessed the performance impact of the feature.
- [X] My changes do not introduce new warnings or errors.
- [X] I have checked for compatibility with other parts of the codebase.